### PR TITLE
chore: Bump dependencies.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,54 +4,45 @@ version = 3
 
 [[package]]
 name = "bitflags"
-version = "1.3.2"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
-
-[[package]]
-name = "cfg-if"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
 
 [[package]]
 name = "libc"
-version = "0.2.139"
+version = "0.2.155"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
+checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
 
 [[package]]
 name = "log"
-version = "0.4.17"
+version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
-dependencies = [
- "cfg-if",
-]
+checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.50"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ef7d57beacfaf2d8aee5937dab7b7f28de3cb8b1828479bb5de2a7106f2bae2"
+checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.23"
+version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b"
+checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
 name = "rppal"
-version = "0.14.1"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "612e1a22e21f08a246657c6433fe52b773ae43d07c9ef88ccfc433cc8683caba"
+checksum = "ae44db779bd0898047804d22b662a9dc533b142c077b3f7e36003f658835c5b9"
 dependencies = [
  "libc",
 ]
@@ -68,9 +59,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.107"
+version = "2.0.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f4064b5b16e03ae50984a5a8ed5d4f8803e6bc1fd170a3cda91a1be4b18e3f5"
+checksum = "dc4b9b9bf2add8093d3f2c0204471e951b2285580335de42f9d2534f3ae7a8af"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -79,18 +70,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.38"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a9cd18aa97d5c45c6603caea1da6628790b37f7a34b6ca89522331c5180fed0"
+checksum = "c0342370b38b6a11b6cc11d6a805569958d54cfa061a29969c3b5ce2ea405724"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.38"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fb327af4685e4d03fa8cbcf1716380da910eeb2bb8be417e7f9fd3fb164f36f"
+checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -99,6 +90,6 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.6"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84a22b9f218b40614adcb3f4ff08b703773ad44fa9423e4e0d346d5db86e4ebc"
+checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,9 +22,9 @@ edition = "2021"
 resolver = "2"
 
 [dependencies]
-bitflags = "1.3.2"
+bitflags = "2.6"
 log = "0.4.17"
-rppal = "0.14.0"
+rppal = "0.18.0"
 thiserror = "1.0.37"
 
 [features]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -216,6 +216,7 @@ impl fmt::Display for RegisterAddress {
 
 bitflags! {
     /// I/O Expander Configuration Register (`IOCON`) bit definitions.
+    #[derive(Debug, PartialEq)]
     pub struct IOCON: u8 {
         /// Controls how the registers are addressed:
         ///
@@ -278,32 +279,32 @@ impl IOCON {
     /// banks. (*Not currently supported in this library.*)
     pub const BANK_ON: IOCON = IOCON::BANK;
     /// The registers are in the same bank (addresses are interleaved sequentially).
-    pub const BANK_OFF: IOCON = IOCON { bits: 0 };
+    pub const BANK_OFF: IOCON = IOCON::empty();
     /// The `INT` pins are internally connected.
     pub const MIRROR_ON: IOCON = IOCON::MIRROR;
     /// The `INT` pins are not connected. `INTA` is associated with `PORTA` and `INTB`
     /// is associated with `PORTB`.
-    pub const MIRROR_OFF: IOCON = IOCON { bits: 0 };
+    pub const MIRROR_OFF: IOCON = IOCON::empty();
     /// Sequential operation enabled, address pointer increments.
-    pub const SEQOP_ON: IOCON = IOCON { bits: 0 };
+    pub const SEQOP_ON: IOCON = IOCON::empty();
     /// Sequential operation disabled, address pointer does not increment.
     pub const SEQOP_OFF: IOCON = IOCON::SEQOP;
     /// Slew rate control enabled.
-    pub const DISSLW_SLEW_RATE_CONTROLLED: IOCON = IOCON { bits: 0 };
+    pub const DISSLW_SLEW_RATE_CONTROLLED: IOCON = IOCON::empty();
     /// Slew rate control disabled.
     pub const DISSLW_SLEW_RATE_MAX: IOCON = IOCON::DISSLW;
     /// Enables the MCP23S17 address pins.
     pub const HAEN_ON: IOCON = IOCON::HAEN;
     /// Disables the MCP23S17 address pins.
-    pub const HAEN_OFF: IOCON = IOCON { bits: 0 };
+    pub const HAEN_OFF: IOCON = IOCON::empty();
     /// Open-drain output (overrides the `INTPOL` bit.)
     pub const ODR_ON: IOCON = IOCON::ODR;
     /// Active driver output (`INTPOL` bit sets the polarity.)
-    pub const ODR_OFF: IOCON = IOCON { bits: 0 };
+    pub const ODR_OFF: IOCON = IOCON::empty();
     /// Active-high.
     pub const INTPOL_HIGH: IOCON = IOCON::INTPOL;
     /// Active-low.
-    pub const INTPOL_LOW: IOCON = IOCON { bits: 0 };
+    pub const INTPOL_LOW: IOCON = IOCON::empty();
 }
 
 /// The MCP23S17 has two GPIO ports, GPIOA and GPIOB.


### PR DESCRIPTION
Update bitflags to use new API for empty flags.