### PR TITLE
chore: Explicitly test that the claimed MSRV still compiles successfully.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rust: [stable, beta, nightly]
+        rust: [1.85.0, stable, beta, nightly]
         # os: [ubuntu-latest, windows-latest, macOS-latest]
         os: [ubuntu-latest]
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,10 +22,7 @@ jobs:
         profile: minimal
         override: true
     - name: Install cargo-make
-      uses: actions-rs/cargo@v1
-      with:
-        command: install
-        args: --debug cargo-make
+      uses: davidB/rust-cargo-make@v1
     - name: Run CI
       if: matrix.rust != 'nightly'
       uses: actions-rs/cargo@v1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ repository = "https://github.com/solimike/rppal-mcp23s17/"
 keywords = ["MCP23S17", "Raspberry", "Raspberry_Pi", "PiFaceDigital", "RPPAL"]
 categories = ["hardware-support", "embedded"]
 edition = "2024"
-rust-version = "1.85"
+rust-version = "1.85"   # If bumping MSRV, update ci.yml to reflect new version too.
 
 # When using the "mockspi" feature for dev builds the original resolver's desire
 # to merge features between release and test builds is inappropriate, so use the

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -70,7 +70,6 @@ script = [
 	"cargo semver-checks --target ${TARGET}",
 ]
 
-
 [tasks.prepare_commit]
 workspace = false
 dependencies = [


### PR DESCRIPTION
Added the MSRV to the test matrix. This flushed out that cargo-make has a newer MSRV so moved to pre-compiled versions of cargo-make, which also had the pleasant side effect of speeding up the CI runs.